### PR TITLE
Fix #13

### DIFF
--- a/backend_resources/javascript/builtins.js
+++ b/backend_resources/javascript/builtins.js
@@ -1,106 +1,106 @@
-{
-    "::i8": {
-        size_of: function(input) { return 1; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeInt8(input, offset);
-            return offset+1;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readInt8(offset), offset+1];
-        },
+module.exports = {
+  '::i8': {
+    size_of: function (input) { return 1 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeInt8(input, offset)
+      return offset + 1
     },
-    "::u8": {
-        size_of: function(input) { return 1; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeInt8(input, offset);
-            return offset+1;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readInt8(offset), offset+1];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readInt8(offset), size: offset + 1}
+    }
+  },
+  '::u8': {
+    size_of: function (input) { return 1 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeInt8(input, offset)
+      return offset + 1
     },
-    "::i16": {
-        size_of: function(input) { return 2; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeInt16BE(input, offset);
-            return offset+2;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readInt16BE(offset), offset+2];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readInt8(offset), size: offset + 1}
+    }
+  },
+  '::i16': {
+    size_of: function (input) { return 2 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeInt16BE(input, offset)
+      return offset + 2
     },
-    "::u16": {
-        size_of: function(input) { return 2; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeUInt16BE(input, offset);
-            return offset+2;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readUInt16BE(offset), offset+2];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readInt16BE(offset), size: offset + 2}
+    }
+  },
+  '::u16': {
+    size_of: function (input) { return 2 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeUInt16BE(input, offset)
+      return offset + 2
     },
-    "::i32": {
-        size_of: function(input) { return 4; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeInt32BE(input, offset);
-            return offset+4;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readInt32BE(offset), offset+4];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readUInt16BE(offset), size: offset + 2}
+    }
+  },
+  '::i32': {
+    size_of: function (input) { return 4 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeInt32BE(input, offset)
+      return offset + 4
     },
-    "::u32": {
-        size_of: function(input) { return 4; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeUInt32BE(input, offset);
-            return offset+4;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readUInt32BE(offset), offset+4];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readInt32BE(offset), size: offset + 4}
+    }
+  },
+  '::u32': {
+    size_of: function (input) { return 4 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeUInt32BE(input, offset)
+      return offset + 4
     },
-    "::i64": {
-        size_of: function(input) { return 8; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeInt64BE(input, offset);
-            return offset+8;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readInt64BE(offset), offset+8];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readUInt32BE(offset), size: offset + 4}
+    }
+  },
+  '::i64': {
+    size_of: function (input) { return 8 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeInt64BE(input, offset)
+      return offset + 8
     },
-    "::u64": {
-        size_of: function(input) { return 8; },
-        serialize: function(input, buffer, offset) {
-            buffer.writeUInt64BE(input, offset);
-            return offset+8;
-        },
-        deserialize: function(buffer, offset) {
-            return [buffer.readUInt64BE(offset), offset+8];
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readInt64BE(offset), size: offset + 8}
+    }
+  },
+  '::u64': {
+    size_of: function (input) { return 8 },
+    serialize: function (input, buffer, offset) {
+      buffer.writeUInt64BE(input, offset)
+      return offset + 8
     },
-    "::varint": {
-        size_of: function(value) {
-            let cursor = 0;
-            while(value & ~0x7F) {
-                value >>>= 7;
-                cursor++;
-            }
-            return cursor + 1;
-        },
+    deserialize: function (buffer, offset) {
+      return {value: buffer.readUInt64BE(offset), size: offset + 8}
+    }
+  },
+  '::varint': {
+    size_of: function (value) {
+      let cursor = 0
+      while (value & ~0x7F) {
+        value >>>= 7
+        cursor++
+      }
+      return cursor + 1
+    }
+  },
+  '::sized_string': {
+    size_of: function (input) { return Buffer.byteLength(input, 'utf8') },
+    serialize: function (input, buffer, offset) {
+      return offset + buffer.write(input, offset)
     },
-    "::sized_string": {
-        size_of: function(input) { return Buffer.byteLength(input, 'utf8'); },
-        serialize: function(input, buffer, offset) {
-            return offset + buffer.write(input, offset);
-        },
-        deserialize: function(buffer, offset, size) {
-            return [buffer.toString('utf8', offset, offset+size), offset+size];
-        },
-    },
-    "::unit": {
-        size_of: function(input) { return 0; },
-        serialize: function(input, buffer, offset) { return offset; },
-        deserialize: function(buffer, offset) { return [null, offset] },
-    },
+    deserialize: function (buffer, offset, size) {
+      return {value: buffer.toString('utf8', offset, offset + size), size: offset + size}
+    }
+  },
+  '::unit': {
+    size_of: function (input) { return 0 },
+    serialize: function (input, buffer, offset) { return offset },
+    deserialize: function (buffer, offset) { return {value: null, size: offset} }
+  }
 }

--- a/src/backend/javascript/cu_to_js.rs
+++ b/src/backend/javascript/cu_to_js.rs
@@ -53,7 +53,7 @@ pub fn generate_deserialize(fun_name: String, typ: TypeContainer) -> Result<Bloc
     let mut ib = Block::new();
 
     ib.scope(super::ib_to_js::build_block(&base)?);
-    ib.return_(format!("[{}, offset]",
+    ib.return_(format!("{{ value: {}, size: offset }}",
                        ib::utils::output_for_type(&typ.clone())).into());
 
     let mut b = Block::new();
@@ -76,7 +76,7 @@ pub fn generate_compilation_unit(cu: &CompilationUnit) -> Result<Block> {
 
     for typ in specs {
         let typ_inner = typ.borrow();
-        
+
         let typ_base_name = format!("{}_{}", typ_inner.type_id, typ_inner.path.str_name());
         let typ_name_size_of = format!("sizeOf_{}", typ_base_name);
         let typ_name_serialize = format!("serialize_{}", typ_base_name);
@@ -105,7 +105,7 @@ pub fn generate_compilation_unit(cu: &CompilationUnit) -> Result<Block> {
             TypeKind::Native(_) => {
                 b.var_assign(
                     typ_name_size_of.clone(),
-                    format!("types[\"{}\"][\"size_of\"]", typ_ns_name).into()
+                    format!("types[\"{}\"][\"sizeOf\"]", typ_ns_name).into()
                 );
                 b.var_assign(
                     typ_name_serialize.clone(),
@@ -121,11 +121,11 @@ pub fn generate_compilation_unit(cu: &CompilationUnit) -> Result<Block> {
 
     let exports_inner = exports.iter()
         .map(|&(ref ns_path, ref internal_name)| {
-            format!("\"{}\": {{\"size_of\": {i}_size_of, \"serialize\": {i}_serialize, \"deserialize\": {i}_deserialize }}",
+            format!("\"{}\": {{\"sizeOf\": sizeOf_{i}, \"serialize\": serialize_{i}, \"deserialize\": deserialize_{i} }}",
                     ns_path, i = internal_name)
         })
         .join(",\n");
-    b.var_assign("exports".into(), format!("{{\n{}\n}}", exports_inner).into());
+    b.assign("module.exports".into(), format!("{{\n{}\n}}", exports_inner).into());
 
     Ok(b)
 }

--- a/src/backend/javascript/ib_to_js.rs
+++ b/src/backend/javascript/ib_to_js.rs
@@ -140,8 +140,8 @@ pub fn build_block(block: &ib::Block) -> Result<Block> {
                     }
                     ib::CallType::Deserialize(ref output) => {
                         b.var_assign(format!("call_out"), call.into());
-                        b.var_assign(format!("{}", output), format!("call_out[0]").into());
-                        b.var_assign(format!("offset"), format!("call_out[1]").into())
+                        b.var_assign(format!("{}", output), format!("call_out.value").into());
+                        b.var_assign(format!("offset"), format!("call_out.size").into())
                     }
                 }
             }


### PR DESCRIPTION
- Also fix JavaScript output (identifiers starting with numbers and undefined identifiers because of naming mix-ups)
- Use `module.exports` for `builtins.js` and outputted JavaScript